### PR TITLE
Android sdkVersionの設定

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -116,6 +116,7 @@
     <source-file src="src/android/drawable-xxhdpi/icn_flash_on.png" target-dir="app/src/main/res/drawable-xxhdpi"/>
     <source-file src="src/android/drawable-xxhdpi/icn_blackboard_edit.png" target-dir="app/src/main/res/drawable-xxhdpi"/>
     <source-file src="src/android/drawable-xxhdpi/icn_blackboard.png" target-dir="app/src/main/res/drawable-xxhdpi"/>
+    <framework src="src/android/build-extras.gradle" custom="true" type="gradleReference" />
 
   </platform>
 </plugin>

--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -1,0 +1,6 @@
+android {
+    defaultConfig {
+        minSdkVersion 21
+        targetSdkVersion 29
+    }
+}


### PR DESCRIPTION
Gradleのバージョンを上げたことで、Manifest.xmlのtargetVersion指定はNGとなったため、build.gradleに追加する