### PR TITLE
iOS16以上と以下で回転処理を分ける

### DIFF
--- a/src/ios/CameraViewController.swift
+++ b/src/ios/CameraViewController.swift
@@ -138,7 +138,9 @@ class CameraViewController: UIViewController {
         hCameraButtonCenterConstraint, hCameraViewAspectConstraint, hCameraViewBottomConstraint, hCameraViewTopConstraint,
         hBlackBoardEdit01Constraint, hBlackBoardEdit02Constraint, hBlackBoardMode01Constraint, hBlackBoardMode02Constraint]
         // 回転イベントを通知
-        NotificationCenter.default.addObserver(self, selector: #selector(CameraViewController.onOrientationDidChange(notification:)), name: UIDevice.orientationDidChangeNotification, object: nil)
+        if #unavailable(iOS 16.0) {
+            NotificationCenter.default.addObserver(self, selector: #selector(CameraViewController.onOrientationDidChange(notification:)), name: UIDevice.orientationDidChangeNotification, object: nil)
+        }
         // 監視を有効にする
         try! audioSession.setActive(true)
         currentVolumn = audioSession.outputVolume // 初期値を設定
@@ -196,6 +198,14 @@ class CameraViewController: UIViewController {
         // ボリューム通知を解除
         print("[viewDidDisappear] removeObserver:outputVolume")
         audioSession.removeObserver(self, forKeyPath: "outputVolume")
+    }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        coordinator.animate { _ in
+            // 画面回転後のUI更新処理など
+            self.rotationCamera()
+        }
     }
 
     override func observeValue(forKeyPath keyPath: String?, of object: Any?,


### PR DESCRIPTION
## issue <!-- #issue番号を記載してください -->
https://github.com/ncdcdev/KuiManagementSystem/issues/2450

## 変更内容 <!-- 行った変更を簡略に記載してください -->
- ios16で回転のタイミングがかわったため、ios16以上では`viewWillTransition`で判定するように修正

## 確認したこと <!-- 何を以て変更要件を満たしていると判断したかを記載してください -->
- iPhone13(iOS14)で回転確認
- iPhone7(iOS15.7.3)で回転確認

## スクリーンショット <!--  変更がわかる画面があれば記載してください -->
- iPhone13(iOS14)
### 横向き
![Screen Shot 2023-02-15 at 21 44 55](https://user-images.githubusercontent.com/6349913/219044458-3c3b356d-d912-42c3-af95-5e7247ffabd1.png)
### 縦向き
![Screen Shot 2023-02-15 at 21 45 00](https://user-images.githubusercontent.com/6349913/219044469-5759811a-9a80-4348-81f2-4ea141a6f460.png)


## 補足事項 <!-- 補足で説明が必要な場合記載してください -->

ただ、端末を横向きの地面向きにして撮影すると、保存処理後にカメラに戻るが、
iPhone13：カメラ画像は縦向き、ボタンは横向きのレイアウト
iPhone7：全体的に縦向きになる（既存）
になる