### PR TITLE
cordovaの最新版対応

### DIFF
--- a/hooks/on-uninstall.js
+++ b/hooks/on-uninstall.js
@@ -1,52 +1,53 @@
-const fs = require('fs');
-const path = require('path');
-const xml2js = require('xml2js');
+const fs = require("fs");
+const path = require("path");
+const xml2js = require("xml2js");
+const q = require("q");
 
 const PLUGIN_ID = "cordova-plugin-blackboard-camera";
 const androidPlatformRoot = "./platforms/android/";
 
-let  deferral;
+let deferral;
 
-function removeKotlinSourceFiles(){
-
-    const pluginXML = fs.readFileSync('./plugins/'+PLUGIN_ID+'/plugin.xml').toString();
-    const parser = new xml2js.Parser();
-    parser.parseString(pluginXML, (error, config) => {
-        if (error) return;
-        if (!config.plugin.hasOwnProperty('platform')) return;
-        for (let platform of config.plugin.platform)
-            if (platform['$'].name === 'android') {
-                if (platform.hasOwnProperty('source-file')){
-                    let sourceFiles = platform['source-file'];
-                    for(let sourceFile of sourceFiles){
-                        if (sourceFile['$'].hasOwnProperty('src')){
-                            let src = sourceFile['$']['src'];
-                            if(src.match(/\.kt/)){
-                                let srcParts = src.split('/');
-                                let filename = srcParts[srcParts.length - 1];
-                                let filepath = sourceFile['$']['target-dir'];
-                                filepath = androidPlatformRoot+filepath+'/'+filename;
-                                if(fs.existsSync(path.resolve(filepath))){
-                                    fs.unlinkSync(filepath);
-                                    console.log("Removed Kotlin source file: "+filepath);
-                                }
-                            }
-                        }
-                    }
+function removeKotlinSourceFiles() {
+  const pluginXML = fs.readFileSync("./plugins/" + PLUGIN_ID + "/plugin.xml").toString();
+  const parser = new xml2js.Parser();
+  parser.parseString(pluginXML, (error, config) => {
+    if (error) return;
+    if (!config.plugin.hasOwnProperty("platform")) return;
+    for (let platform of config.plugin.platform)
+      if (platform["$"].name === "android") {
+        if (platform.hasOwnProperty("source-file")) {
+          let sourceFiles = platform["source-file"];
+          for (let sourceFile of sourceFiles) {
+            if (sourceFile["$"].hasOwnProperty("src")) {
+              let src = sourceFile["$"]["src"];
+              if (src.match(/\.kt/)) {
+                let srcParts = src.split("/");
+                let filename = srcParts[srcParts.length - 1];
+                let filepath = sourceFile["$"]["target-dir"];
+                filepath = androidPlatformRoot + filepath + "/" + filename;
+                if (fs.existsSync(path.resolve(filepath))) {
+                  fs.unlinkSync(filepath);
+                  console.log("Removed Kotlin source file: " + filepath);
                 }
-                break;
+              }
             }
-    });
+          }
+        }
+        break;
+      }
+  });
 }
-module.exports = function(ctx) {
-    try{
-        deferral = ctx.requireCordovaModule('q').defer();
-        removeKotlinSourceFiles();
-        deferral.resolve();
-    }catch(e){
-        let msg = e.toString();
-        console.dir(e);
-        deferral.reject(msg);
-        return deferral.promise;
-    }
+
+module.exports = function (ctx) {
+  try {
+    deferral = q.defer();
+    removeKotlinSourceFiles();
+    deferral.resolve();
+  } catch (e) {
+    let msg = e.toString();
+    console.dir(e);
+    deferral.reject(msg);
+    return deferral.promise;
+  }
 };

--- a/hooks/support-kotlin.js
+++ b/hooks/support-kotlin.js
@@ -1,60 +1,61 @@
-const fs = require('fs');
-const xml2js = require('xml2js');
+const fs = require("fs");
+const xml2js = require("xml2js");
+const q = require("q");
 
 const PLUGIN_ID = "cordova-plugin-blackboard-camera";
-const gradlePath = './platforms/android/app/build.gradle'; // cordova-android@7+ path
+const gradlePath = "./platforms/android/app/build.gradle"; // cordova-android@7+ path
 
-let  deferral;
+let deferral;
 
-function addSupport(){
-    let defaultArgs = {
-        kotlin_version: '\text.kotlin_version = "latest.integration"\n\t',
-        kotlin_android: 'apply plugin: "kotlin-android"',
-        classpath: ' \t\tclasspath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"'
-    };
-    const pluginXML = fs.readFileSync('./plugins/'+PLUGIN_ID+'/plugin.xml').toString();
-    const gradle = fs.readFileSync(gradlePath).toString();
-    let text = gradle;
-    const parser = new xml2js.Parser();
-    parser.parseString(pluginXML, (error, config) => {
-        if (error) return;
-        if (!config.plugin.hasOwnProperty('platform')) return;
-        for (let x of config.plugin.platform)
-            if (x['$'].name === 'android') {
-                if (x['$'].hasOwnProperty('kotlin')) defaultArgs.kotlin_version = `\text.kotlin_version = "${x['$'].kotlin}"\n\t`;
-                if (x.hasOwnProperty('apply-plugin')) defaultArgs.apply_plugin = x['apply-plugin'];
-                break;
-            }
-        if (!gradle.match(/ext.kotlin_version/g)) append(defaultArgs.kotlin_version, /buildscript(\s*)\{\s*/g);
-        if (!gradle.match(/kotlin-gradle-plugin/g)) append(defaultArgs.classpath, /classpath\s+(['"])[\w.:]+(['"])/g);
-        if (!gradle.match(/apply\s+plugin(\s*:\s*)(['"])kotlin-android(['"])/g)) append(defaultArgs.kotlin_android);
-        if (defaultArgs.apply_plugin)
-            for (let x of defaultArgs.apply_plugin) {
-                const reg = new RegExp(`apply\\s+plugin(\\s*:\\s*)(['"])${x}(['"])`, 'g');
-                if (!gradle.match(reg)) append(`apply plugin: "${x}"`);
-            }
-    });
+function addSupport() {
+  let defaultArgs = {
+    kotlin_version: '\text.kotlin_version = "latest.integration"\n\t',
+    kotlin_android: 'apply plugin: "kotlin-android"',
+    classpath: ' \t\tclasspath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"',
+  };
+  const pluginXML = fs.readFileSync("./plugins/" + PLUGIN_ID + "/plugin.xml").toString();
+  const gradle = fs.readFileSync(gradlePath).toString();
+  let text = gradle;
+  const parser = new xml2js.Parser();
+  parser.parseString(pluginXML, (error, config) => {
+    if (error) return;
+    if (!config.plugin.hasOwnProperty("platform")) return;
+    for (let x of config.plugin.platform)
+      if (x["$"].name === "android") {
+        if (x["$"].hasOwnProperty("kotlin")) defaultArgs.kotlin_version = `\text.kotlin_version = "${x["$"].kotlin}"\n\t`;
+        if (x.hasOwnProperty("apply-plugin")) defaultArgs.apply_plugin = x["apply-plugin"];
+        break;
+      }
+    if (!gradle.match(/ext.kotlin_version/g)) append(defaultArgs.kotlin_version, /buildscript(\s*)\{\s*/g);
+    if (!gradle.match(/kotlin-gradle-plugin/g)) append(defaultArgs.classpath, /classpath\s+(['"])[\w.:]+(['"])/g);
+    if (!gradle.match(/apply\s+plugin(\s*:\s*)(['"])kotlin-android(['"])/g)) append(defaultArgs.kotlin_android);
+    if (defaultArgs.apply_plugin)
+      for (let x of defaultArgs.apply_plugin) {
+        const reg = new RegExp(`apply\\s+plugin(\\s*:\\s*)(['"])${x}(['"])`, "g");
+        if (!gradle.match(reg)) append(`apply plugin: "${x}"`);
+      }
+  });
 
-    function append(edit, reg) {
-        if (reg === undefined) reg = /com.android.application['"]/g;
-        const pos = text.search(reg);
-        const len = text.match(reg)[0].length;
-        const header = text.substring(0, pos + len);
-        const footer = text.substring(pos + len);
-        text = header + '\n' + edit + footer;
-    }
+  function append(edit, reg) {
+    if (reg === undefined) reg = /com.android.application['"]/g;
+    const pos = text.search(reg);
+    const len = text.match(reg)[0].length;
+    const header = text.substring(0, pos + len);
+    const footer = text.substring(pos + len);
+    text = header + "\n" + edit + footer;
+  }
 
-    fs.writeFileSync(gradlePath, text);
+  fs.writeFileSync(gradlePath, text);
 }
-module.exports = function(ctx) {
-    try{
-        deferral = ctx.requireCordovaModule('q').defer();
-        addSupport();
-        deferral.resolve();
-    }catch(e){
-        let msg = e.toString();
-        console.dir(e);
-        deferral.reject(msg);
-        return deferral.promise;
-    }
+module.exports = function (ctx) {
+  try {
+    deferral = q.defer();
+    addSupport();
+    deferral.resolve();
+  } catch (e) {
+    let msg = e.toString();
+    console.dir(e);
+    deferral.reject(msg);
+    return deferral.promise;
+  }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,27 @@
+{
+    "name": "cordova-plugin-blackboard-camera",
+    "version": "1.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "sax": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+        },
+        "xml2js": {
+            "version": "0.4.23",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+            "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+            "requires": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~11.0.0"
+            }
+        },
+        "xmlbuilder": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,14 @@
 {
     "name": "cordova-plugin-blackboard-camera",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "q": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
+        },
         "sax": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "kotlin"
     ],
     "dependencies": {
+        "q": "^1.5.1",
         "xml2js": "^0.4.19"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,14 +1,18 @@
 {
-    "version": "1.0.0",
+    "version": "1.1.0",
     "name": "cordova-plugin-blackboard-camera",
     "cordova_name": "Blackboard Camera",
-    "description": "",
+    "description": "cordova plugin for blackboard camera",
     "cordova": {
         "id": "cordova-plugin-blackboard-camera",
         "platforms": [
             "android",
             "ios"
         ]
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com:ncdcdev/cordova-plugin-blackboard-camera.git"
     },
     "keywords": [
         "ecosystem:cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -87,9 +87,9 @@
       <string name="request_write_storage_permission">このアプリはストレージへの書き込みの許可が必要です</string>
       <string name="camera_error">This device doesn\'t support Camera2 API.</string>
     </config-file>
-    <edit-config file="AndroidManifest.xml" target="/manifest/application" mode="merge">
+    <!-- <edit-config file="AndroidManifest.xml" target="/manifest/application" mode="merge">
         <application android:largeHeap="true"></application>
-    </edit-config>
+    </edit-config> -->
     <!-- <edit-config file="AndroidManifest.xml" target="/manifest/application" mode="overwrite">
         <application android:theme="@style/Theme.AppCompat.NoActionBar"></application>
     </edit-config> -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -54,9 +54,10 @@
     <!-- Add Kotlin support -->
     <hook type="after_plugin_add" src="hooks/support-kotlin.js" />
     <hook type="after_platform_add" src="hooks/support-kotlin.js" />
-    <framework src="org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.31" />
+    <plugin name="cordova-plugin-androidx-adapter" />
+    <!-- <framework src="org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.31" /> -->
     <!-- <framework src="com.android.support:appcompat-v7:27.1.1" /> -->
-    <apply-plugin>kotlin-android-extensions</apply-plugin>
+    <!-- <apply-plugin>kotlin-android-extensions</apply-plugin> -->
     <apply-plugin>kotlin-kapt</apply-plugin>
 
     <!-- Cleanup Kotlin source on uninstall -->
@@ -79,7 +80,7 @@
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
         <!-- <meta-data android:name="theme" android:value="@style/Theme.AppCompat.NoActionBar" /> -->
         <!-- <meta-data android:name="largeHeap" android:value="true" /> -->
-        <activity android:label="Camera Activity" android:name="jp.co.taisei.construction.fieldmanagement.plugin.CameraActivity"></activity>
+        <activity android:label="Camera Activity" android:name="jp.co.taisei.construction.fieldmanagement.plugin.CameraActivity" android:theme="@style/Theme.AppCompat.NoActionBar"></activity>
     </config-file>
     <config-file target="res/values/strings.xml" parent="/resources">
       <string name="camera">カメラ起動</string>

--- a/plugin.xml
+++ b/plugin.xml
@@ -47,7 +47,7 @@
 
     <framework src="AVFoundation.framework" />
 
-    <dependency id="cordova-plugin-add-swift-support" version="1.7.2"/>
+    <dependency id="cordova-plugin-add-swift-support" version="2.0.2"/>
   </platform>
 
   <platform name="android" kotlin="1.5.21">

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
+<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-blackboard-camera"
-        version="1.0.0">
+        version="1.1.0">
 
   <name>Blackboard Camera</name>
 
   <engines>
-    <engine name="cordova" version=">=7.1.0"/>
+    <engine name="cordova" version=">=11.0.0"/>
     <!-- <engine name="cordova-android" version=">=7.0.0"/>
     <engine name="cordova-ios" version=">=7.0.0"/> -->
   </engines>
@@ -50,13 +50,12 @@
     <dependency id="cordova-plugin-add-swift-support" version="1.7.2"/>
   </platform>
 
-  <platform name="android"
-            kotlin="1.3.0">
+  <platform name="android" kotlin="1.5.21">
     <!-- Add Kotlin support -->
     <hook type="after_plugin_add" src="hooks/support-kotlin.js" />
     <hook type="after_platform_add" src="hooks/support-kotlin.js" />
     <framework src="org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.31" />
-    <framework src="com.android.support:appcompat-v7:27.1.1" />
+    <!-- <framework src="com.android.support:appcompat-v7:27.1.1" /> -->
     <apply-plugin>kotlin-android-extensions</apply-plugin>
     <apply-plugin>kotlin-kapt</apply-plugin>
 
@@ -67,6 +66,7 @@
     <config-file target="config.xml" parent="/*">
       <feature name="BlackboardCamera">
         <param name="android-package" value="jp.co.taisei.construction.fieldmanagement.plugin.BlackboardCamera"/>
+        <param name="onload" value="true" />
       </feature>
     </config-file>
 

--- a/src/android/Camera2Fragment.kt
+++ b/src/android/Camera2Fragment.kt
@@ -17,7 +17,7 @@ import android.media.ImageReader
 import android.media.MediaActionSound
 import android.os.*
 import android.provider.MediaStore
-import android.support.media.ExifInterface
+import androidx.exifinterface.media.ExifInterface
 import android.util.Log
 import android.util.Size
 import android.util.SparseIntArray
@@ -556,7 +556,7 @@ class Camera2Fragment : Fragment(), View.OnClickListener, View.OnTouchListener {
             if (!mCameraOpenCloseLock.tryAcquire(2500, TimeUnit.MILLISECONDS)) {
                 throw RuntimeException("Time out waiting to lock camera opening.")
             }
-            manager.openCamera(mCameraId!!, mStateCallback, mBackgroundHandler)
+            manager.openCamera(mCameraId ?: "Unknown Camera ID", mStateCallback, mBackgroundHandler)
         } catch (e: CameraAccessException) {
             e.printStackTrace()
         } catch (e: InterruptedException) {
@@ -826,13 +826,13 @@ class Camera2Fragment : Fragment(), View.OnClickListener, View.OnTouchListener {
     private fun getJpegOrientation(deviceOrientation: Int): Int {
         var cameraManager = activity.getSystemService(CAMERA_SERVICE) as CameraManager
 
-        val characteristics = cameraManager.getCameraCharacteristics(mCameraId)
+        val characteristics = cameraManager.getCameraCharacteristics(mCameraId ?: "Unknown Camera ID")
         val sensorOrientation = characteristics.get(CameraCharacteristics.SENSOR_ORIENTATION)
 
         // Round device orientation to a multiple of 90
         val newDeviceOrientation = (deviceOrientation + 45) / 90 * 90
 
-        return (sensorOrientation + newDeviceOrientation + 360) % 360
+        return (sensorOrientation!! + newDeviceOrientation + 360) % 360
 
     }
 

--- a/src/android/Camera2Fragment.kt
+++ b/src/android/Camera2Fragment.kt
@@ -1122,7 +1122,9 @@ class Camera2Fragment : Fragment(), View.OnClickListener, View.OnTouchListener {
                 0 -> {
                     // AUTO
                     requestBuilder.set(CaptureRequest.CONTROL_MODE, CameraMetadata.CONTROL_MODE_AUTO)
-                    requestBuilder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CameraMetadata.CONTROL_AE_PRECAPTURE_TRIGGER_START)
+                    requestBuilder.set(CaptureRequest.CONTROL_AE_MODE, CameraMetadata.CONTROL_AE_MODE_ON)
+                    requestBuilder.set(CaptureRequest.CONTROL_AE_MODE, CameraMetadata.CONTROL_AF_MODE_CONTINUOUS_PICTURE)
+                    requestBuilder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CameraMetadata.CONTROL_AE_PRECAPTURE_TRIGGER_IDLE)
                     requestBuilder.set(CaptureRequest.CONTROL_AE_MODE, CameraMetadata.CONTROL_AE_MODE_ON_AUTO_FLASH)
                     requestBuilder.set(CaptureRequest.FLASH_MODE, CameraMetadata.FLASH_MODE_OFF)
                     Log.d(TAG, "testLog:AUTO")

--- a/src/android/CameraActivity.kt
+++ b/src/android/CameraActivity.kt
@@ -11,13 +11,13 @@ import android.hardware.SensorManager
 import android.os.Build
 import android.os.Bundle
 import android.os.Environment
-import android.support.v4.app.ActivityCompat
-import android.support.v4.content.ContextCompat
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import android.view.KeyEvent
 //import jp.co.taisei.construction.fieldmanagement.R
-//import jp.co.taisei.construction.fieldmanagement.prod2.R
-import jp.co.taisei.construction.fieldmanagement.develop.R
-import kotlinx.android.synthetic.main.fragment_camera2.*
+import jp.co.taisei.construction.fieldmanagement.prod2.R
+//import jp.co.taisei.construction.fieldmanagement.develop.R
+//import kotlinx.android.synthetic.main.fragment_camera2.*
 import org.apache.cordova.CordovaActivity
 
 class CameraActivity : CordovaActivity(), SensorEventListener, ActivityCompat.OnRequestPermissionsResultCallback {
@@ -62,9 +62,9 @@ class CameraActivity : CordovaActivity(), SensorEventListener, ActivityCompat.On
                     .replace(R.id.container, instance)
                     .commit()
         }
-        this.boardPath = intent.extras["boardPath"] as String?
-        this.isNeedBlackBoard = intent.extras["isNeedBlackBoard"] as Boolean
-        this.blackboardViewPriority = intent.extras["blackboardViewPriority"] as String
+        this.boardPath = intent.extras?.get("boardPath") as String?
+        this.isNeedBlackBoard = intent.extras?.get("isNeedBlackBoard") as Boolean
+        this.blackboardViewPriority = intent.extras!!["blackboardViewPriority"] as String
 
         checkPermission()
     }


### PR DESCRIPTION
## issue <!-- #issue番号を記載してください -->
#27 

Java 11が必要

## Android 変更内容

### プラグインのインストール
- エラーログ
```
❯ npx cordova plugin add 'https://github.com/ncdcdev/cordova-plugin-blackboard-camera.git#feature/update_cordova_9'
Installing "cordova-plugin-blackboard-camera" for android
Failed to install 'cordova-plugin-blackboard-camera': Error: There was a conflict trying to modify attributes with <edit-config> in plugin cordova-plugin-blackboard-camera. The conflicting plugin, undefined, already modified the same attributes. The conflict must be resolved before cordova-plugin-blackboard-camera can be added. You may use --force to add the plugin and overwrite the conflicting attributes.
    at PlatformMunger.add_plugin_changes (/Users/jang/git/KuiManagementSystem/app/node_modules/cordova-common/src/ConfigChanges/ConfigChanges.js:120:19)
    at /Users/jang/git/KuiManagementSystem/app/node_modules/cordova-common/src/PluginManager.js:121:33
    at _fulfilled (/Users/jang/git/KuiManagementSystem/app/node_modules/q/q.js:854:54)
    at /Users/jang/git/KuiManagementSystem/app/node_modules/q/q.js:883:30
    at Promise.promise.promiseDispatch (/Users/jang/git/KuiManagementSystem/app/node_modules/q/q.js:816:13)
    at /Users/jang/git/KuiManagementSystem/app/node_modules/q/q.js:877:14
    at runSingle (/Users/jang/git/KuiManagementSystem/app/node_modules/q/q.js:137:13)
    at flush (/Users/jang/git/KuiManagementSystem/app/node_modules/q/q.js:125:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:77:11)
There was a conflict trying to modify attributes with <edit-config> in plugin cordova-plugin-blackboard-camera. The conflicting plugin, undefined, already modified the same attributes. The conflict must be resolved before cordova-plugin-blackboard-camera can be added. You may use --force to add the plugin and overwrite the conflicting attributes.
```

- 解決
`plugin.xml`から`edit-config`を削除することで対応



### ビルド時の問題
1. `CordovaError: Using "requireCordovaModule" to load non-cordova module "q" is not supported.`
【対応】
`hooks/on-uninstall.js`に`q = require("q")`を使うように修正

2. エラーログ
The 'kotlin-android-extensions' Gradle plugin is deprecated.
Please use this migration guide (https://goo.gle/kotlin-android-extensions-deprecation) to start working with View Binding (https://developer.android.com/topic/libraries/view-binding) and the 'kotlin-parcelize' plugin.
【対応】
`plugin.xml`から以下を削除
`<apply-plugin>kotlin-android-extensions</apply-plugin>`


### Import問題
- `android.support.media.ExifInterface`の参照失敗
  - 対応
    - Android Supportライブラリは現在非推奨とされており、代わりにAndroidXライブラリが推奨
    - AndroidXライブラリには、`androidx.exifinterface.ExifInterface` クラスが含まれている
- `android.support.v4.app.ActivityCompat`→`androidx.core.app.ActivityCompat`
- `android.support.v4.content.ContextCompat` → `androidx.core.content.ContextCompat`

### Android12以上でカメラボタンをタップしても反応しない
```
I/ViewRootImpl@9a5d955[CameraActivity]: ViewPostIme pointer 0
I/ViewRootImpl@9a5d955[CameraActivity]: ViewPostIme pointer 1
D/Camera2Fragment: test:lockFocus:start
D/Camera2Fragment: test:lockFocus:end
D/Camera2Fragment: test:CaptureCallback:STATE_WAITING_LOCK:3
D/Camera2Fragment: test:runPrecaptureSequence
D/Camera2Fragment: test:CaptureCallback:STATE_WAITING_PRECAPTURE
D/Camera2Fragment: test:CaptureCallback:STATE_WAITING_NON_PRECAPTURE
D/Camera2Fragment: test:CaptureCallback:STATE_WAITING_NON_PRECAPTURE
D/Camera2Fragment: test:CaptureCallback:STATE_WAITING_NON_PRECAPTURE
```
`Camera2Fragment`の`CameraCaptureSession.CaptureCallback()`から次のステータスが取れない
`STATE_WAITING_NON_PRECAPTURE`：カメラがオートフォーカスと露出を調整している

- 対応
`requestBuilder.set(CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER, CameraMetadata.CONTROL_AE_PRECAPTURE_TRIGGER_IDLE)`設定でカメラは動作した

### 権限確認で落ちる
写真保存の際に表示される権限確認でAndroid12で落ってしまう
→対応中

## iOS変更内容
### platformの設置エラー
```
Dependent plugin "cordova-plugin-file" already installed on ios.
Failed to install 'cordova-plugin-photo-library-sism': CordovaError: Version of installed plugin: "cordova-plugin-add-swift-support@1.7.2" does not satisfy dependency plugin requirement "cordova-plugin-add-swift-support@^2.0.2". Try --force to use installed plugin as dependency.
    at /Users/jang/git/KuiManagementSystem/app/node_modules/cordova-lib/src/plugman/install.js:526:43
Failed to restore plugin "cordova-plugin-photo-library-sism". You might need to try adding it again. Error: CordovaError: Version of installed plugin: "cordova-plugin-add-swift-support@1.7.2" does not satisfy dependency plugin requirement "cordova-plugin-add-swift-support@^2.0.2". Try --force to use installed plugin as dependency.
```
→本体のpackage.jsonに`"cordova-plugin-add-swift-support": "^2.0.2",　"cordova-plugin-inappbrowser": "^5.0.0"`を追加

### ビルドエラー
`Could not build Objective-C module 'Cordova'`
→カメラのplugin`cordova-plugin-photo-library-sism`が正しく動作しない？

## 確認したこと <!-- 何を以て変更要件を満たしていると判断したかを記載してください -->

## スクリーンショット <!--  変更がわかる画面があれば記載してください -->

## 補足事項 <!-- 補足で説明が必要な場合記載してください -->
