### PR TITLE
Xmp header android

### DIFF
--- a/hooks/move_exifInterface.js
+++ b/hooks/move_exifInterface.js
@@ -1,8 +1,8 @@
 var fs = require("fs");
 var path = require("path");
+var Q = require("q");
 
 module.exports = function (context) {
-  var Q = context.requireCordovaModule("q");
   var deferral = new Q.defer();
   var targetFiles = ["ExifInterfaceFix.java", "ExifInterfaceUtils.java"];
 

--- a/hooks/move_exifInterface.js
+++ b/hooks/move_exifInterface.js
@@ -1,30 +1,34 @@
-var fs = require("fs");
+var fs = require("fs").promises;
 var path = require("path");
-var Q = require("q");
 
-module.exports = function (context) {
-  var deferral = new Q.defer();
+module.exports = async function (context) {
   var targetFiles = ["ExifInterfaceFix.java", "ExifInterfaceUtils.java"];
 
-  targetFiles.map(fileName => {
+  for (const fileName of targetFiles) {
     var sourceFile = path.join(
       context.opts.projectRoot,
       `platforms/android/app/src/main/java/jp/co/taisei/construction/fieldmanagement/plugin/${fileName}`
     );
-    var targetFile = path.join(
+    var targetDir = path.join(
       context.opts.projectRoot,
-      `platforms/android/app/src/main/java/androidx/exifinterface/media/${fileName}`
+      "platforms/android/app/src/main/java/androidx/exifinterface/media"
     );
+    var targetFile = path.join(targetDir, fileName);
 
-    fs.rename(sourceFile, targetFile, function (err) {
-      if (err) {
-        deferral.reject("Error moving file: " + err);
-      } else {
-        console.log("File moved successfully");
-        deferral.resolve();
-      }
-    });
-  });
+    // コピー先ディレクトリが存在するか確認し、存在しない場合は作成する
+    try {
+      await fs.access(targetDir, fs.constants.F_OK);
+    } catch (err) {
+      await fs.mkdir(targetDir, { recursive: true });
+    }
 
-  return deferral.promise;
+    // ファイルの移動
+    try {
+      await fs.rename(sourceFile, targetFile);
+      console.log("File moved successfully");
+    } catch (err) {
+      console.error("Error moving file: " + err);
+      throw err; // エラーを外部に伝播させる
+    }
+  }
 };

--- a/plugin.xml
+++ b/plugin.xml
@@ -102,6 +102,7 @@
     </edit-config> -->
 
     <framework src="com.android.support:exifinterface:27.1.1" />
+    <framework src="com.adobe.xmp:xmpcore:6.1.11"/>
 
     <source-file src="src/android/BlackboardCamera.kt" target-dir="app/src/main/java/jp/co/taisei/construction/fieldmanagement/plugin"/>
     <source-file src="src/android/CameraActivity.kt" target-dir="app/src/main/java/jp/co/taisei/construction/fieldmanagement/plugin"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -110,6 +110,7 @@
     <source-file src="src/android/SensorOrientation.kt" target-dir="app/src/main/java/jp/co/taisei/construction/fieldmanagement/plugin"/>
     <source-file src="src/android/ElectronicBlackBoardManager.kt" target-dir="app/src/main/java/jp/co/taisei/construction/fieldmanagement/plugin"/>
     <source-file src="src/android/PhotoInfo.kt" target-dir="app/src/main/java/jp/co/taisei/construction/fieldmanagement/plugin"/>
+    <source-file src="src/android/XmpUtil.java" target-dir="app/src/main/java/jp/co/taisei/construction/fieldmanagement/plugin"/>
 
     <source-file src="src/android/layout/activity_main.xml" target-dir="app/src/main/res/layout"/>
     <source-file src="src/android/layout-land/fragment_camera2.xml" target-dir="app/src/main/res/layout-land"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -102,7 +102,7 @@
     </edit-config> -->
 
     <framework src="com.android.support:exifinterface:27.1.1" />
-    <framework src="com.adobe.xmp:xmpcore:6.1.11"/>
+    <framework src="com.adobe.xmp:xmpcore:5.1.3"/>
 
     <source-file src="src/android/BlackboardCamera.kt" target-dir="app/src/main/java/jp/co/taisei/construction/fieldmanagement/plugin"/>
     <source-file src="src/android/CameraActivity.kt" target-dir="app/src/main/java/jp/co/taisei/construction/fieldmanagement/plugin"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -110,6 +110,8 @@
     <source-file src="src/android/SensorOrientation.kt" target-dir="app/src/main/java/jp/co/taisei/construction/fieldmanagement/plugin"/>
     <source-file src="src/android/ElectronicBlackBoardManager.kt" target-dir="app/src/main/java/jp/co/taisei/construction/fieldmanagement/plugin"/>
     <source-file src="src/android/PhotoInfo.kt" target-dir="app/src/main/java/jp/co/taisei/construction/fieldmanagement/plugin"/>
+    <source-file src="src/android/ExifInterfaceFix.java" target-dir="app/src/main/java/jp/co/taisei/construction/fieldmanagement/plugin"/>
+    <source-file src="src/android/ExifInterfaceUtils.java" target-dir="app/src/main/java/jp/co/taisei/construction/fieldmanagement/plugin"/>
     <source-file src="src/android/XmpUtil.java" target-dir="app/src/main/java/jp/co/taisei/construction/fieldmanagement/plugin"/>
 
     <source-file src="src/android/layout/activity_main.xml" target-dir="app/src/main/res/layout"/>

--- a/src/android/ElectronicBlackBoardManager.kt
+++ b/src/android/ElectronicBlackBoardManager.kt
@@ -1,16 +1,18 @@
 package jp.co.taisei.construction.fieldmanagement.plugin
 
-import android.content.Context
-import java.io.File
 import java.util.*
-import android.graphics.BitmapFactory
-import android.graphics.Bitmap
 import androidx.exifinterface.media.ExifInterfaceFix
+import com.adobe.xmp.XMPConst
 import java.text.SimpleDateFormat
 
 object ElectronicBlackBoardManager {
 
     fun createImageEmbeddedMetaData(path: String, photoInfo: PhotoInfo?, imageDescription: String, model: String, software: String) {
+
+        // http://ns.adobe.com/xap/1.0/情報を先にセットする
+        val xmpMeta = XmpUtil.extractOrCreateXMPMeta(path)
+        xmpMeta.setProperty(XMPConst.NS_XMP, "Label", "TPR2");
+        XmpUtil.writeXMPMeta(path, xmpMeta)
 
         val formatter = SimpleDateFormat("yyyy:MM:dd HH:mm:ss", Locale.US)
         val now = Date()

--- a/src/android/ExifInterfaceFix.java
+++ b/src/android/ExifInterfaceFix.java
@@ -3937,7 +3937,7 @@ public class ExifInterfaceFix {
      * @throws IOException if an I/O error occurs while retrieving file descriptor via
      *         {@link FileInputStream#getFD()}.
      */
-    public ExifInterface2(@NonNull File file) throws IOException {
+    public ExifInterfaceFix(@NonNull File file) throws IOException {
         if (file == null) {
             throw new NullPointerException("file cannot be null");
         }
@@ -3952,7 +3952,7 @@ public class ExifInterfaceFix {
      * @throws IOException if an I/O error occurs while retrieving file descriptor via
      *         {@link FileInputStream#getFD()}.
      */
-    public ExifInterface2(@NonNull String filename) throws IOException {
+    public ExifInterfaceFix(@NonNull String filename) throws IOException {
         if (filename == null) {
             throw new NullPointerException("filename cannot be null");
         }
@@ -3968,7 +3968,7 @@ public class ExifInterfaceFix {
      * @throws NullPointerException if file descriptor is null
      * @throws IOException if an error occurs while duplicating the file descriptor.
      */
-    public ExifInterface2(@NonNull FileDescriptor fileDescriptor) throws IOException {
+    public ExifInterfaceFix(@NonNull FileDescriptor fileDescriptor) throws IOException {
         if (fileDescriptor == null) {
             throw new NullPointerException("fileDescriptor cannot be null");
         }
@@ -4011,7 +4011,7 @@ public class ExifInterfaceFix {
      * @param inputStream the input stream that contains the image data
      * @throws NullPointerException if the input stream is null
      */
-    public ExifInterface2(@NonNull InputStream inputStream) throws IOException {
+    public ExifInterfaceFix(@NonNull InputStream inputStream) throws IOException {
         this(inputStream, STREAM_TYPE_FULL_IMAGE_DATA);
     }
 
@@ -4027,7 +4027,7 @@ public class ExifInterfaceFix {
      * @throws IOException if an I/O error occurs while retrieving file descriptor via
      *         {@link FileInputStream#getFD()}.
      */
-    public ExifInterface2(@NonNull InputStream inputStream, @ExifStreamType int streamType)
+    public ExifInterfaceFix(@NonNull InputStream inputStream, @ExifStreamType int streamType)
             throws IOException {
         if (inputStream == null) {
             throw new NullPointerException("inputStream cannot be null");
@@ -5067,7 +5067,7 @@ public class ExifInterfaceFix {
         if (location == null) {
             return;
         }
-        setAttribute(ExifInterface2.TAG_GPS_PROCESSING_METHOD, location.getProvider());
+        setAttribute(ExifInterfaceFix.TAG_GPS_PROCESSING_METHOD, location.getProvider());
         setLatLong(location.getLatitude(), location.getLongitude());
         setAltitude(location.getAltitude());
         // Location objects store speeds in m/sec. Translates it to km/hr here.
@@ -5076,8 +5076,8 @@ public class ExifInterfaceFix {
                 * TimeUnit.HOURS.toSeconds(1) / 1000).toString());
         String[] dateTime = sFormatterPrimary.format(
                 new Date(location.getTime())).split("\\s+", -1);
-        setAttribute(ExifInterface2.TAG_GPS_DATESTAMP, dateTime[0]);
-        setAttribute(ExifInterface2.TAG_GPS_TIMESTAMP, dateTime[1]);
+        setAttribute(ExifInterfaceFix.TAG_GPS_DATESTAMP, dateTime[0]);
+        setAttribute(ExifInterfaceFix.TAG_GPS_TIMESTAMP, dateTime[1]);
     }
 
     /**
@@ -5155,11 +5155,11 @@ public class ExifInterfaceFix {
     }
 
     /**
-     * Returns parsed {@link ExifInterface2#TAG_DATETIME} value as number of milliseconds since
+     * Returns parsed {@link ExifInterfaceFix#TAG_DATETIME} value as number of milliseconds since
      * Jan. 1, 1970, midnight local time.
      *
      * <p>Note: The return value includes the first three digits (or less depending on the length
-     * of the string) of {@link ExifInterface2#TAG_SUBSEC_TIME}.
+     * of the string) of {@link ExifInterfaceFix#TAG_SUBSEC_TIME}.
      *
      * @return null if date time information is unavailable or invalid.
      *
@@ -5174,11 +5174,11 @@ public class ExifInterfaceFix {
     }
 
     /**
-     * Returns parsed {@link ExifInterface2#TAG_DATETIME_DIGITIZED} value as number of
+     * Returns parsed {@link ExifInterfaceFix#TAG_DATETIME_DIGITIZED} value as number of
      * milliseconds since Jan. 1, 1970, midnight local time.
      *
      * <p>Note: The return value includes the first three digits (or less depending on the length
-     * of the string) of {@link ExifInterface2#TAG_SUBSEC_TIME_DIGITIZED}.
+     * of the string) of {@link ExifInterfaceFix#TAG_SUBSEC_TIME_DIGITIZED}.
      *
      * @return null if digitized date time information is unavailable or invalid.
      *
@@ -5193,11 +5193,11 @@ public class ExifInterfaceFix {
     }
 
     /**
-     * Returns parsed {@link ExifInterface2#TAG_DATETIME_ORIGINAL} value as number of
+     * Returns parsed {@link ExifInterfaceFix#TAG_DATETIME_ORIGINAL} value as number of
      * milliseconds since Jan. 1, 1970, midnight local time.
      *
      * <p>Note: The return value includes the first three digits (or less depending on the length
-     * of the string) of {@link ExifInterface2#TAG_SUBSEC_TIME_ORIGINAL}.
+     * of the string) of {@link ExifInterfaceFix#TAG_SUBSEC_TIME_ORIGINAL}.
      *
      * @return null if original date time information is unavailable or invalid.
      *
@@ -5920,18 +5920,18 @@ public class ExifInterfaceFix {
                 }
 
                 if (rotation != null) {
-                    int orientation = ExifInterface2.ORIENTATION_NORMAL;
+                    int orientation = ExifInterfaceFix.ORIENTATION_NORMAL;
 
                     // all rotation angles in CW
                     switch (Integer.parseInt(rotation)) {
                         case 90:
-                            orientation = ExifInterface2.ORIENTATION_ROTATE_90;
+                            orientation = ExifInterfaceFix.ORIENTATION_ROTATE_90;
                             break;
                         case 180:
-                            orientation = ExifInterface2.ORIENTATION_ROTATE_180;
+                            orientation = ExifInterfaceFix.ORIENTATION_ROTATE_180;
                             break;
                         case 270:
-                            orientation = ExifInterface2.ORIENTATION_ROTATE_270;
+                            orientation = ExifInterfaceFix.ORIENTATION_ROTATE_270;
                             break;
                     }
 

--- a/src/android/XmpUtil.java
+++ b/src/android/XmpUtil.java
@@ -1,0 +1,635 @@
+package jp.co.taisei.construction.fieldmanagement.plugin;
+
+/*
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import android.util.Log;
+
+import com.adobe.xmp.XMPException;
+import com.adobe.xmp.XMPMeta;
+import com.adobe.xmp.XMPMetaFactory;
+import com.adobe.xmp.options.SerializeOptions;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Formatter;
+import java.util.List;
+
+/**
+ * Util class to read/write xmp from a jpeg image file. It only supports jpeg
+ * image format, and doesn't support extended xmp now.
+ * To use it:
+ * XMPMeta xmpMeta = XmpUtil.extractOrCreateXMPMeta(filename);
+ * xmpMeta.setProperty(PanoConstants.GOOGLE_PANO_NAMESPACE, "property_name", "value");
+ * XmpUtil.writeXMPMeta(filename, xmpMeta);
+ *
+ * Or if you don't care the existing XMP meta data in image file:
+ * XMPMeta xmpMeta = XmpUtil.createXMPMeta();
+ * xmpMeta.setPropertyBoolean(PanoConstants.GOOGLE_PANO_NAMESPACE, "bool_property_name", "true");
+ * XmpUtil.writeXMPMeta(filename, xmpMeta);
+ */
+public class XmpUtil {
+    private static final String TAG = "XmpUtil";
+    private static final int XMP_HEADER_SIZE = 29;
+    private static final String XMP_HEADER = "http://ns.adobe.com/xap/1.0/\0";
+    private static final int MAX_XMP_BUFFER_SIZE = 65502;
+
+    private static final String EXTENDED_XMP_HEADER_SIGNATURE = "http://ns.adobe.com/xmp/extension/\0";
+    private static final String XMP_NOTE_NAMESPACE = "http://ns.adobe.com/xmp/note/";
+    private static final String NOTE_PREFIX = "xmpNote";
+
+    private static final int MAX_EXTENDED_XMP_BUFFER_SIZE = 65000;
+    private static final int EXTEND_XMP_HEADER_SIZE = 75;
+
+    private static final String GOOGLE_PANO_NAMESPACE = "http://ns.google.com/photos/1.0/panorama/";
+    private static final String PANO_PREFIX = "GPano";
+
+    private static final int M_SOI = 0xd8; // File start marker.
+    private static final int M_APP1 = 0xe1; // Marker for Exif or XMP.
+    private static final int M_SOS = 0xda; // Image data marker.
+
+    // Jpeg file is composed of many sections and image data. This class is used
+    // to hold the section data from image file.
+    private static class Section {
+        public int marker;
+        public int length;
+        public byte[] data;
+    }
+
+    static {
+        try {
+            XMPMetaFactory.getSchemaRegistry().registerNamespace(
+                    GOOGLE_PANO_NAMESPACE, PANO_PREFIX);
+
+            XMPMetaFactory.getSchemaRegistry().registerNamespace(
+                    XMP_NOTE_NAMESPACE, NOTE_PREFIX);
+        } catch (XMPException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Extracts XMPMeta from JPEG image file.
+     *
+     * @param filename JPEG image file name.
+     * @return Extracted XMPMeta or null.
+     */
+    public static XMPMeta extractXMPMeta(String filename) {
+        if (!filename.toLowerCase().endsWith(".jpg")
+                && !filename.toLowerCase().endsWith(".jpeg")) {
+            Log.d(TAG, "XMP parse: only jpeg file is supported");
+            return null;
+        }
+
+        try {
+            return extractXMPMeta(new FileInputStream(filename));
+        } catch (FileNotFoundException e) {
+            Log.e(TAG, "Could not read file: " + filename, e);
+            return null;
+        }
+    }
+
+    /**
+     *  Extracts XMPMeta from a JPEG image file stream.
+     *
+     * @param is the input stream containing the JPEG image file.
+     * @return Extracted XMPMeta or null.
+     */
+    public static XMPMeta extractXMPMeta(InputStream is) {
+        List<Section> sections = parse(is, true);
+        if (sections == null) {
+            return null;
+        }
+        // Now we don't support extended xmp.
+        for (Section section : sections) {
+            if (hasXMPHeader(section.data)) {
+                int end = getXMPContentEnd(section.data);
+                byte[] buffer = new byte[end - XMP_HEADER_SIZE];
+                System.arraycopy(
+                        section.data, XMP_HEADER_SIZE, buffer, 0, buffer.length);
+                try {
+                    XMPMeta result = XMPMetaFactory.parseFromBuffer(buffer);
+                    return result;
+                } catch (XMPException e) {
+                    Log.d(TAG, "XMP parse error", e);
+                    return null;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Creates a new XMPMeta.
+     */
+    public static XMPMeta createXMPMeta() {
+        return XMPMetaFactory.create();
+    }
+
+    /**
+     * Tries to extract XMP meta from image file first, if failed, create one.
+     */
+    public static XMPMeta extractOrCreateXMPMeta(String filename) {
+        XMPMeta meta = extractXMPMeta(filename);
+        return meta == null ? createXMPMeta() : meta;
+    }
+
+    /**
+     * Writes the XMPMeta to the jpeg image file.
+     */
+    public static boolean writeXMPMeta(String filename, XMPMeta meta) {
+        if (!filename.toLowerCase().endsWith(".jpg")
+                && !filename.toLowerCase().endsWith(".jpeg")) {
+            Log.d(TAG, "XMP parse: only jpeg file is supported");
+            return false;
+        }
+        List<Section> sections = null;
+        try {
+            sections = parse(new FileInputStream(filename), false);
+            sections = insertXMPSection(sections, meta);
+            if (sections == null) {
+                return false;
+            }
+        } catch (FileNotFoundException e) {
+            Log.e(TAG, "Could not read file: " + filename, e);
+            return false;
+        }
+        FileOutputStream os = null;
+        try {
+            // Overwrite the image file with the new meta data.
+            os = new FileOutputStream(filename);
+            writeJpegFile(os, sections);
+        } catch (IOException e) {
+            Log.d(TAG, "Write file failed:" + filename, e);
+            return false;
+        } finally {
+            if (os != null) {
+                try {
+                    os.close();
+                } catch (IOException e) {
+                    // Ignore.
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Updates a jpeg file from inputStream with XMPMeta to outputStream.
+     */
+    public static boolean writeXMPMeta(InputStream inputStream, OutputStream outputStream,
+                                       XMPMeta meta) {
+        List<Section> sections = parse(inputStream, false);
+        sections = insertXMPSection(sections, meta);
+        if (sections == null) {
+            return false;
+        }
+        try {
+            // Overwrite the image file with the new meta data.
+            writeJpegFile(outputStream, sections);
+        } catch (IOException e) {
+            Log.d(TAG, "Write to stream failed", e);
+            return false;
+        } finally {
+            if (outputStream != null) {
+                try {
+                    outputStream.close();
+                } catch (IOException e) {
+                    // Ignore.
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Write a list of sections to a Jpeg file.
+     */
+    private static void writeJpegFile(OutputStream os, List<Section> sections)
+            throws IOException {
+        // Writes the jpeg file header.
+        os.write(0xff);
+        os.write(M_SOI);
+        for (Section section : sections) {
+            os.write(0xff);
+            os.write(section.marker);
+            if (section.length > 0) {
+                // It's not the image data.
+                int lh = section.length >> 8;
+                int ll = section.length & 0xff;
+                os.write(lh);
+                os.write(ll);
+            }
+            os.write(section.data);
+        }
+    }
+
+    private static List<Section> insertXMPSection(
+            List<Section> sections, XMPMeta meta) {
+        if (sections == null || sections.size() <= 1) {
+            return null;
+        }
+        byte[] buffer;
+        try {
+            SerializeOptions options = new SerializeOptions();
+            options.setUseCompactFormat(true);
+            // We have to omit packet wrapper here because
+            // javax.xml.parsers.DocumentBuilder
+            // fails to parse the packet end <?xpacket end="w"?> in android.
+            options.setOmitPacketWrapper(true);
+            buffer = XMPMetaFactory.serializeToBuffer(meta, options);
+        } catch (XMPException e) {
+            Log.d(TAG, "Serialize xmp failed", e);
+            return null;
+        }
+        if (buffer.length > MAX_XMP_BUFFER_SIZE) {
+            // Do not support extended xmp now.
+            return null;
+        }
+        // The XMP section starts with XMP_HEADER and then the real xmp data.
+        byte[] xmpdata = new byte[buffer.length + XMP_HEADER_SIZE];
+        System.arraycopy(XMP_HEADER.getBytes(), 0, xmpdata, 0, XMP_HEADER_SIZE);
+        System.arraycopy(buffer, 0, xmpdata, XMP_HEADER_SIZE, buffer.length);
+        Section xmpSection = new Section();
+        xmpSection.marker = M_APP1;
+        // Adds the length place (2 bytes) to the section length.
+        xmpSection.length = xmpdata.length + 2;
+        xmpSection.data = xmpdata;
+
+        for (int i = 0; i < sections.size(); ++i) {
+            // If we can find the old xmp section, replace it with the new one.
+            if (sections.get(i).marker == M_APP1
+                    && hasXMPHeader(sections.get(i).data)) {
+                // Replace with the new xmp data.
+                sections.set(i, xmpSection);
+                return sections;
+            }
+        }
+        // If the first section is Exif, insert XMP data before the second section,
+        // otherwise, make xmp data the first section.
+        List<Section> newSections = new ArrayList<Section>();
+        int position = (sections.get(0).marker == M_APP1) ? 1 : 0;
+        newSections.addAll(sections.subList(0, position));
+        newSections.add(xmpSection);
+        newSections.addAll(sections.subList(position, sections.size()));
+        return newSections;
+    }
+
+    /**
+     * Checks whether the byte array has XMP header. The XMP section contains
+     * a fixed length header XMP_HEADER.
+     *
+     * @param data Xmp metadata.
+     */
+    private static boolean hasXMPHeader(byte[] data) {
+        if (data.length < XMP_HEADER_SIZE) {
+            return false;
+        }
+        try {
+            byte[] header = new byte[XMP_HEADER_SIZE];
+            System.arraycopy(data, 0, header, 0, XMP_HEADER_SIZE);
+            if (new String(header, "UTF-8").equals(XMP_HEADER)) {
+                return true;
+            }
+        } catch (UnsupportedEncodingException e) {
+            return false;
+        }
+        return false;
+    }
+
+    /**
+     * Gets the end of the xmp meta content. If there is no packet wrapper,
+     * return data.length, otherwise return 1 + the position of last '>'
+     * without '?' before it.
+     * Usually the packet wrapper end is "<?xpacket end="w"?> but
+     * javax.xml.parsers.DocumentBuilder fails to parse it in android.
+     *
+     * @param data xmp metadata bytes.
+     * @return The end of the xmp metadata content.
+     */
+    private static int getXMPContentEnd(byte[] data) {
+        for (int i = data.length - 1; i >= 1; --i) {
+            if (data[i] == '>') {
+                if (data[i - 1] != '?') {
+                    return i + 1;
+                }
+            }
+        }
+        // It should not reach here for a valid xmp meta.
+        return data.length;
+    }
+
+    /**
+     * Parses the jpeg image file. If readMetaOnly is true, only keeps the Exif
+     * and XMP sections (with marker M_APP1) and ignore others; otherwise, keep
+     * all sections. The last section with image data will have -1 length.
+     *
+     * @param is Input image data stream.
+     * @param readMetaOnly Whether only reads the metadata in jpg.
+     * @return The parse result.
+     */
+    private static List<Section> parse(InputStream is, boolean readMetaOnly) {
+        try {
+            if (is.read() != 0xff || is.read() != M_SOI) {
+                return null;
+            }
+            List<Section> sections = new ArrayList<Section>();
+            int c;
+            while ((c = is.read()) != -1) {
+                if (c != 0xff) {
+                    return null;
+                }
+                // Skip padding bytes.
+                while ((c = is.read()) == 0xff) {
+                }
+                if (c == -1) {
+                    return null;
+                }
+                int marker = c;
+                if (marker == M_SOS) {
+                    // M_SOS indicates the image data will follow and no metadata after
+                    // that, so read all data at one time.
+                    if (!readMetaOnly) {
+                        Section section = new Section();
+                        section.marker = marker;
+                        section.length = -1;
+                        section.data = new byte[is.available()];
+                        is.read(section.data, 0, section.data.length);
+                        sections.add(section);
+                    }
+                    return sections;
+                }
+                int lh = is.read();
+                int ll = is.read();
+                if (lh == -1 || ll == -1) {
+                    return null;
+                }
+                int length = lh << 8 | ll;
+                if (!readMetaOnly || c == M_APP1) {
+                    Section section = new Section();
+                    section.marker = marker;
+                    section.length = length;
+                    section.data = new byte[length - 2];
+                    is.read(section.data, 0, length - 2);
+                    sections.add(section);
+                } else {
+                    // Skip this section since all exif/xmp meta will be in M_APP1
+                    // section.
+                    is.skip(length - 2);
+                }
+            }
+            return sections;
+        } catch (IOException e) {
+            Log.d(TAG, "Could not parse file.", e);
+            return null;
+        } finally {
+            if (is != null) {
+                try {
+                    is.close();
+                } catch (IOException e) {
+                    // Ignore.
+                }
+            }
+        }
+    }
+
+    private static Section createStandardXMPSection(XMPMeta meta) {
+        byte[] buffer;
+        try {
+            SerializeOptions options = new SerializeOptions();
+            options.setUseCompactFormat(true);
+            // We have to omit packet wrapper here because
+            // javax.xml.parsers.DocumentBuilder
+            // fails to parse the packet end <?xpacket end="w"?> in android.
+            options.setOmitPacketWrapper(true);
+            buffer = XMPMetaFactory.serializeToBuffer(meta, options);
+        } catch (XMPException e) {
+            Log.d(TAG, "Serialize xmp failed", e);
+            return null;
+        }
+        if (buffer.length > MAX_XMP_BUFFER_SIZE) {
+            Log.e(TAG, "exceed max size");
+            return null;
+        }
+        // The XMP section starts with XMP_HEADER and then the real xmp data.
+        byte[] xmpdata = new byte[buffer.length + XMP_HEADER_SIZE];
+        System.arraycopy(XMP_HEADER.getBytes(), 0, xmpdata, 0, XMP_HEADER_SIZE);
+        System.arraycopy(buffer, 0, xmpdata, XMP_HEADER_SIZE, buffer.length);
+        Section xmpSection = new Section();
+        xmpSection.marker = M_APP1;
+        // Adds the length place (2 bytes) to the section length.
+        xmpSection.length = xmpdata.length + 2;
+        xmpSection.data = xmpdata;
+
+        return xmpSection;
+    }
+
+    private static Section createSection(byte[] portionOfExtendedMeta, byte[] headerBytes) {
+
+        if (portionOfExtendedMeta.length > MAX_EXTENDED_XMP_BUFFER_SIZE) {
+            // Do not support extended xmp now.
+            Log.e(TAG, "createSection fail exceed max size");
+            return null;
+        }
+
+        byte[] xmpdata = new byte[portionOfExtendedMeta.length + 75];
+        System.arraycopy(headerBytes, 0, xmpdata, 0, headerBytes.length);
+
+        System.arraycopy(portionOfExtendedMeta, 0, xmpdata, headerBytes.length, portionOfExtendedMeta.length);
+        Section xmpSection = new Section();
+        xmpSection.marker = M_APP1;
+        // Adds the length place (2 bytes) to the section length.
+        xmpSection.length = xmpdata.length + 2;
+        xmpSection.data = xmpdata;
+        ByteBuffer byteBuffer2 = ByteBuffer.wrap(xmpdata);
+        Log.d(TAG, "fullLength=" + byteBuffer2.getInt(67) + " offset=" + byteBuffer2.getInt(71));
+        return xmpSection;
+    }
+
+    /**
+     * Split extendXMPMeta to multiple marker segments
+     * @param extendedXMPMetaBytes serialized extended XMP
+     * @param guid Is a 128-bit MD5 digest of the full ExtendedXMP serialization,
+     *             stored as a 32-byte ASCII hex string
+     * @return  split result
+     */
+    private static List<Section> splitExtendXMPMeta(byte[] extendedXMPMetaBytes, String guid){
+        List<Section> sections = new ArrayList<Section>();
+     /*
+    The extended XMP JPEG marker segment content holds:
+    - a signature string, "http://ns.adobe.com/xmp/extension/\0"
+    - a 128 bit GUID stored as a 32 byte ASCII hex string
+    - a UInt32 full length of the entire extended XMP
+    - a UInt32 offset for this portion of the extended XMP
+    - the UTF-8 text for this portion of the extended XMP
+     */
+        int splitNum = extendedXMPMetaBytes.length/MAX_EXTENDED_XMP_BUFFER_SIZE;
+        byte[] portion = new byte[MAX_EXTENDED_XMP_BUFFER_SIZE];
+        ByteBuffer byteBuffer = ByteBuffer.wrap(extendedXMPMetaBytes);
+        Section extendedXmpSection = null;
+
+        byte[] headerBytes = new byte[EXTEND_XMP_HEADER_SIZE];
+        int index = 0;
+        System.arraycopy(EXTENDED_XMP_HEADER_SIGNATURE.getBytes(), 0, headerBytes, 0, EXTENDED_XMP_HEADER_SIGNATURE.length());
+        index += EXTENDED_XMP_HEADER_SIGNATURE.length();
+
+        System.arraycopy(guid.getBytes(), 0, headerBytes, index, guid.length());
+        index += guid.length();
+
+        Log.d(TAG, "buffer.length=" + extendedXMPMetaBytes.length);
+        byte[] fullLengthBytes = new byte[4];
+        ByteBuffer intBuffer = ByteBuffer.wrap(fullLengthBytes);
+        intBuffer.putInt(0, extendedXMPMetaBytes.length);
+        System.arraycopy(fullLengthBytes, 0, headerBytes, index, 4);
+        index += 4;
+
+        byte[] offsetBytes = new byte[4];
+        ByteBuffer offsetBuffer = ByteBuffer.wrap(offsetBytes);
+        for( int i=0; i < splitNum; ++i ) {
+            offsetBuffer.putInt(0, i*MAX_EXTENDED_XMP_BUFFER_SIZE);
+            System.arraycopy(offsetBytes, 0, headerBytes, index, 4);
+
+            byteBuffer.get(portion);
+            extendedXmpSection = createSection(portion, headerBytes);
+            sections.add(extendedXmpSection);
+        }
+
+        int remainSize = extendedXMPMetaBytes.length - splitNum*MAX_EXTENDED_XMP_BUFFER_SIZE;
+        if (  remainSize > 0 ) {
+            offsetBuffer.putInt(0, splitNum*MAX_EXTENDED_XMP_BUFFER_SIZE);
+            System.arraycopy(offsetBytes, 0, headerBytes, index, 4);
+
+            byte[] remain = new byte[remainSize];
+            byteBuffer.get(remain);
+            extendedXmpSection = createSection(remain, headerBytes);
+            sections.add(extendedXmpSection);
+        }
+
+        return sections;
+    }
+
+    /**
+     *  Updates a jpeg file from inputStream with XMPMeta to outputStream.
+     * @param inputStream Input image data stream
+     * @param outputStream Output image data stream
+     * @param standardMeta The main portion of the metadata tree must be serialized and written as
+     *                     the standard XMP packet
+     * @param extendedMeta The extended portion must be serialized without a packet wrapper,
+     *                     and written as a series of APP1 marker segments
+     */
+    public static boolean writeXMPMeta(InputStream inputStream, OutputStream outputStream,
+                                       XMPMeta standardMeta, XMPMeta extendedMeta) {
+        byte[] buffer;
+        try {
+            SerializeOptions options = new SerializeOptions();
+            options.setUseCompactFormat(true);
+            // We have to omit packet wrapper here because
+            // javax.xml.parsers.DocumentBuilder
+            // fails to parse the packet end <?xpacket end="w"?> in android.
+            options.setOmitPacketWrapper(true);
+            buffer = XMPMetaFactory.serializeToBuffer(extendedMeta, options);
+        } catch (XMPException e) {
+            Log.d(TAG, "Serialize extended xmp failed", e);
+            return false;
+        }
+
+        String guid = getGUID(buffer);
+        try {
+            standardMeta.setProperty(XMP_NOTE_NAMESPACE, "HasExtendedXMP", guid);
+        } catch (XMPException exception) {
+            Log.d(TAG, "set XMPMeta Property", exception);
+            return false;
+        }
+        List<Section> sections = parse(inputStream, false);
+        List<Section> xmpSections = new ArrayList<Section>();
+        Section standardXmpSection = createStandardXMPSection(standardMeta);
+        if (standardXmpSection == null) {
+            Log.e(TAG, "create standard meta section error");
+            return false;
+        }
+        xmpSections.add(standardXmpSection);
+
+        List<Section> extendedSections = splitExtendXMPMeta(buffer, guid);
+        xmpSections.addAll(extendedSections);
+        sections = insertXMPSection(sections, xmpSections);
+        if (sections == null) {
+            Log.d(TAG, "Insert XMP fialed");
+            return false;
+        }
+        try {
+            // Overwrite the image file with the new meta data.
+            writeJpegFile(outputStream, sections);
+        } catch (IOException e) {
+            Log.d(TAG, "Write to stream failed", e);
+            return false;
+        } finally {
+            if (outputStream != null) {
+                try {
+                    outputStream.close();
+                } catch (IOException e) {
+                    // Ignore.
+                }
+            }
+        }
+        return true;
+    }
+
+    private static List<Section> insertXMPSection(
+            List<Section> sections, List<Section> xmpSections) {
+        if (sections == null || sections.size() <= 1) {
+            return null;
+        }
+
+        // If the first section is Exif, insert XMP data before the second section,
+        // otherwise, make xmp data the first section.
+        List<Section> newSections = new ArrayList<Section>();
+        int position = (sections.get(0).marker == M_APP1) ? 1 : 0;
+        newSections.addAll(sections.subList(0, position));
+        newSections.addAll(xmpSections);
+        newSections.addAll(sections.subList(position, sections.size()));
+        return newSections;
+    }
+
+    private static String getGUID(byte[] src) {
+        StringBuilder builder = new StringBuilder();
+        try {
+            MessageDigest digester = MessageDigest.getInstance("MD5");
+            digester.update(src);
+            byte[] digest = digester.digest();
+
+            Formatter formatter = new Formatter(builder);
+            for (int i = 0; i < digest.length; ++i) {
+                formatter.format("%02x", ((256 + digest[i]) % 256));
+            }
+        } catch (NoSuchAlgorithmException exception) {
+            Log.d(TAG, "get md5 instance failure" + exception);
+            return null;
+        }
+
+        return builder.toString().toUpperCase();
+    }
+
+    private XmpUtil() {}
+}


### PR DESCRIPTION
## issue <!-- #issue番号を記載してください -->
adobe情報がhedaderに入ってない
https://github.com/ncdcdev/KuiManagementSystem/issues/2603
https://github.com/ncdcdev/cordova-plugin-blackboard-camera/issues/30

## 変更内容 <!-- 行った変更を簡略に記載してください -->
- hook処理で移行先のフォルダが存在しない場合、エラーになる問題対応
- xmpのヘッダーにadobeの情報を入れる処理を追加
- `com.adobe.xmp:xmpcore`のFrameworkを追加

## 確認したこと <!-- 何を以て変更要件を満たしていると判断したかを記載してください -->
- 写真撮影後、ヘッダーにadobeの情報が入っていること

## スクリーンショット <!--  変更がわかる画面があれば記載してください -->

## 補足事項 <!-- 補足で説明が必要な場合記載してください -->

## PR時のセルフチェック <!-- PRのセルフチェックをしてください -->
- [ ] 関数や変数の命名は一目で分かるものになってますか？
- [ ] コメントは適切な量で、誰が見ても分かるコメントになってますか？
- [ ] PR内容に関するテストは書きましたか？
- [ ] PR内容に付随する各種ドキュメントは一緒に修正しましたか？
- [ ] Issue の完了の定義は満たせていますか？
